### PR TITLE
Add clarification about Figma Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ There are two ways to submit:
 > You can submit an issue using the Resource Addition Request template and
 > provide the info about your resource.
 
+This repository is distinct from the [Figma Community](https://www.figma.com/community). Submitting resources to this repository does not guarantee the resources will be featured in the Figma Community.
+
 ## DISCLAIMER
 
 The resources provided are meant to be helpful for Figma development. They are not

--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -9,6 +9,8 @@ Copilot for Figma products._
 
 > Pull Requests are welcome. Please see the [Contributing Guide](../CONTRIBUTING.md) before opening a Pull Request.
 
+This repository is distinct from the [Figma skills page](http://figma.com/community/skills) in the Figma Community. Submitting resources to this repository does not guarantee the resources will be featured in the Figma Community. We'll update the guidance here as we continue to expand the [Figma skills page](http://figma.com/community/skills).
+
 ## DISCLAIMER
 
 The resources provided are meant to be helpful for Figma development. They are not

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -8,6 +8,8 @@ _A collection of open source plugins and resources for Figma + FigJam that have 
 
 > _Pull Requests are being welcomed. Please see the [Contributing Guide](../CONTRIBUTING.md) before opening a Pull Request._
 
+This repository is distinct from the [Figma plugins page](https://www.figma.com/community/plugins) in the Figma Community. Submitting resources to this repository does not guarantee the resources will be featured in the Figma Community. To learn about submitting to the Figma Community, see [Publish plugins to the Figma Community](https://help.figma.com/hc/en-us/articles/360042293394).
+
 ## DISCLAIMER:
 
 The resources provided are meant to be helpful for Figma plugin development. They are not endorsed or sponsored by Figma in any way. **Please do your own due diligence and security review before using any resources listed.**

--- a/widgets/README.md
+++ b/widgets/README.md
@@ -8,6 +8,8 @@ _A collection of open source plugins, widgets and other resources for Figma + Fi
 
 > _Pull Requests are being welcomed. Please see the [Contributing Guide](../CONTRIBUTING.md) before opening a Pull Request._
 
+This repository is distinct from the [Figma Community](https://www.figma.com/community/whiteboarding). Submitting resources to this repository does not guarantee the resources will be featured in the Figma Community. To learn about submitting to the Figma Community, see [Publish widgets to the Figma Community](https://help.figma.com/hc/en-us/articles/4410337103639).
+
 ## DISCLAIMER:
 
 The resources provided are meant to be helpful for Figma plugin and widget development. They are not endorsed or sponsored by Figma in any way. **Please do your own due diligence and security review before using any resources listed.**


### PR DESCRIPTION
This adds a short clarification about the Figma Community and the relationship this repository has (that it's not connected to the community).