### PR TITLE
Add [skill] emote-behavioral-contracts

### DIFF
--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -40,7 +40,7 @@ security review before using any resources listed.**
 #### emote-behavioral-contracts
 
 [SOURCE CODE](https://github.com/rogerod/emote-behavioral-contracts) · [MIT](https://github.com/rogerod/emote-behavioral-contracts/blob/main/LICENSE)
-**MCP Tools:** `get_design_context` `get_screenshot` `get_metadata`
+**MCP Tools:** `get_design_context` `get_metadata` `use_figma`
 Reads Emote behavioral annotation components from a Figma frame and produces implementation-ready behavioral contracts for AI-driven interfaces.
 
 ---

--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -26,7 +26,7 @@ security review before using any resources listed.**
 ---
 
 ## Table of Contents
-
+- [AI Behavior](#ai-behavior)
 - [Accessibility](#accessibility)
 - [Components](#components)
 - [Design Generation](#design-generation)
@@ -34,6 +34,18 @@ security review before using any resources listed.**
 - [Design Systems](#design-systems)
 
 ---
+
+### AI Behavior
+
+#### emote-behavioral-contracts
+
+[SOURCE CODE](https://github.com/rogerod/emote-behavioral-contracts) · [MIT](https://github.com/rogerod/emote-behavioral-contracts/blob/main/LICENSE)
+**MCP Tools:** `figma_mcp`
+Reads Emote behavioral annotation components from a Figma frame and produces implementation-ready behavioral contracts for AI-driven interfaces.
+
+---
+
+**[⬆ Back to TOC](#table-of-contents)**
 
 ### Accessibility
 

--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -40,7 +40,7 @@ security review before using any resources listed.**
 #### emote-behavioral-contracts
 
 [SOURCE CODE](https://github.com/rogerod/emote-behavioral-contracts) · [MIT](https://github.com/rogerod/emote-behavioral-contracts/blob/main/LICENSE)
-**MCP Tools:** `figma_mcp`
+**MCP Tools:** `get_design_context` `get_screenshot` `get_metadata`
 Reads Emote behavioral annotation components from a Figma frame and produces implementation-ready behavioral contracts for AI-driven interfaces.
 
 ---


### PR DESCRIPTION
Adds emote-behavioral-contracts to the AI Behavior section. New category for skills that govern AI behavior at trust-critical moments in UI interactions.