### PR TITLE
Add [resource] Chinese Color Atlas

### DIFF
--- a/additional_resources/README.md
+++ b/additional_resources/README.md
@@ -13,3 +13,9 @@ _A collection of other resources for Figma + FigJam that have been shared on Git
 The resources provided are meant to be helpful for Figma plugin and widget development. They are not endorsed or sponsored by Figma in any way. **Please do your own due diligence and security review before using any resources listed.**
 
 ---
+
+#### Chinese Color Atlas
+
+[SOURCE CODE](https://github.com/chroma-cathy/chinese-color-atlas) · [MIT](https://github.com/chroma-cathy/chinese-color-atlas/blob/main/LICENSE)
+
+A collection of Chinese traditional color tokens, CSS variables, Tailwind theme values, and Figma samples for design systems.


### PR DESCRIPTION
Adds Chinese Color Atlas to Additional Resources.\n\nResource: https://github.com/chroma-cathy/chinese-color-atlas\nLicense: MIT\nTopics include: figma, design-tokens, color-palette\n\nThis is an active open-source resource with Figma samples and design token exports.