### PR TITLE
Add [skill] generate-tokens-from-figma

### DIFF
--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -142,6 +142,13 @@ Audits Figma screens for design system compliance.
 Detects incorrect components, missing token bindings, spacing violations, typography drift, and accessibility issues.
 Outputs structured audit report with fixes.
 
+#### generate-tokens-from-figma
+
+[SOURCE CODE](https://github.com/congemcd/skills-collection/tree/main/skills/generate-tokens-from-figma) · [MIT](https://github.com/congemcd/skills-collection/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+
+Generates design token reports and DTCG token files from Figma variables and styles.
+
 ---
 
 **[⬆ Back to TOC](#table-of-contents)**


### PR DESCRIPTION
## Summary

Adds `generate-tokens-from-figma` to the Agent Skill Resources Design Systems section.

The skill generates design token reports and DTCG token files from Figma variables and styles.

## Resource

- Source: https://github.com/congemcd/skills-collection/tree/main/skills/generate-tokens-from-figma
- License: MIT
- MCP tools: `use_figma`

## Validation

- Confirmed the source skill URL resolves.
- Confirmed the license URL resolves.
- Ran `git diff --check` for the README change.
