### PR TITLE
Add [skill] skills-for-figma (18 Figma MCP skills)

### DIFF
--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -43,6 +43,24 @@ security review before using any resources listed.**
 **MCP Tools:** `get_design_context` `get_variable_defs` `get_screenshot` `use_figma`.
 A skill for integrating APCA contrast compliance directly into the Figma design process. Audits and remaps color variables to meet target Lc thresholds, and generates APCA-compliant component variations across light and dark modes.
 
+#### audit-accessibility-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/audit-accessibility-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Produces a per-component accessibility scorecard covering interaction-state coverage, focus indicators, target size, and color-blind simulation.
+
+#### lint-design-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/lint-design-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_metadata`
+Lints a node tree against WCAG 2.2 and design-system rules, flagging contrast failures, hardcoded colors and styles, and detached components.
+
+#### scan-code-accessibility-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/scan-code-accessibility-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Runs axe-core against HTML in a JSDOM environment and maps violations back to the originating Figma design.
+
 ---
 
 **[⬆ Back to TOC](#table-of-contents)**
@@ -61,12 +79,42 @@ Reads Emote behavioral annotation components from a Figma frame and produces imp
 
 ### Components
 
+#### analyze-component-set-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/analyze-component-set-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_design_context` `get_metadata`
+Analyzes a component set as a variant state machine, mapping variant properties to CSS pseudo-classes and reporting per-variant visual differences.
+
+#### arrange-component-set-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/arrange-component-set-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Arranges a component set's variants into a labeled grid on the canvas, parsing variant names into rows and columns.
+
+#### component-properties-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/component-properties-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Defines a component's property API (boolean, text, instance-swap, and variant properties) and instantiates the component with property values applied.
+
+#### deep-component-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/deep-component-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_design_context` `get_metadata`
+Walks a component to unlimited depth and returns its full node tree with resolved token bindings, main-component references, and prototype reactions.
+
 #### design-react-api
 
 [SOURCE CODE](https://github.com/bitovi/design-react-api) · [MIT](https://github.com/bitovi/design-react-api/blob/main/LICENSE)
 **MCP Tools:** `get_design_context` `get_variable_defs`                                                                          
 A spec-driven skill that analyzes a Figma component and proposes a React component API, props interface, TypeScript types, and  
 variant-to-prop mappings before any implementation begins.                                                                                       
+
+#### generate-component-doc-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/generate-component-doc-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Generates Markdown documentation for a Figma component, including anatomy, tokens, states, accessibility notes, and design-to-code parity.
 
 #### reconstruct-component-figma
 
@@ -86,6 +134,12 @@ A skill that takes a selected Figma frame and rebuilds it as a proper Atomic Des
 **MCP Tools:** `use_figma` `get_design_context` `get_screenshot` `get_variable_defs` `search_design_system` `get_metadata`
 A skill that generates Figma designs fully bound to your design system. Extracts components, variables, and text styles into a local knowledge base, then compiles declarative scene graphs into Figma Plugin API code executed via MCP. All output uses real component instances, bound variables, and token references — no hardcoded values. Includes a recipe system that learns from corrections to improve future generations.
 
+#### build-slides-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/build-slides-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Authors Figma Slides decks — creating and reordering slides, adding text and shapes, and setting backgrounds, transitions, and view mode.
+
 #### bulk-capture
 [SOURCE CODE](https://github.com/tallneil/tallneil-mono-public/tree/main/skills/bulk-capture) · [CC0](https://github.com/tallneil/tallneil-mono-public/blob/main/LICENSE)
 **MCP Tools:** `generate_figma_design` `new_page`
@@ -97,6 +151,24 @@ A skill for bulk-capturing many live web app pages into Figma simultaneously usi
 **[⬆ Back to TOC](#table-of-contents)**
 
 ### Design Process
+
+#### annotations-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/annotations-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Reads and writes designer annotations and annotation categories on Figma nodes.
+
+#### check-design-parity-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/check-design-parity-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_design_context`
+Compares a Figma design node against a code specification and reports drift as scored discrepancies by severity.
+
+#### create-figjam-content
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/create-figjam-content) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Authors and reads FigJam boards — stickies, connectors, shapes with text, sections, tables, and code blocks, with auto-arrange.
 
 #### delight-audit
 
@@ -128,6 +200,12 @@ Generates a complete, ready-to-run FigJam workshop board from a challenge brief,
 
 ### Design Systems
 
+#### design-system-inventory-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/design-system-inventory-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_design_context` `get_metadata`
+Extracts a unified inventory of a file's variables, components, and styles with resolved visual specifications and adaptive compression.
+
 #### ds-init-figma
 
 [SOURCE CODE](https://github.com/arnaudmorvan/ds-init-figma) · [MIT](https://github.com/arnaudmorvan/ds-init-figma/blob/main/LICENSE)
@@ -142,12 +220,42 @@ Audits Figma screens for design system compliance.
 Detects incorrect components, missing token bindings, spacing violations, typography drift, and accessibility issues.
 Outputs structured audit report with fixes.
 
+#### export-tokens-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/export-tokens-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_variable_defs`
+Exports Figma variables to design token files in DTCG, CSS custom properties, Tailwind, SCSS, TypeScript, JSON, Style Dictionary, or Tokens Studio formats, with multi-mode and alias resolution. Works on any Figma plan.
+
 #### generate-tokens-from-figma
 
 [SOURCE CODE](https://github.com/congemcd/skills-collection/tree/main/skills/generate-tokens-from-figma) · [MIT](https://github.com/congemcd/skills-collection/blob/main/LICENSE)
 **MCP Tools:** `use_figma`
 
 Generates design token reports and DTCG token files from Figma variables and styles.
+
+#### import-tokens-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/import-tokens-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_variable_defs`
+Creates and updates Figma variables from DTCG token files, with multi-mode values, alias resolution, and non-destructive matching so re-imports update in place.
+
+#### library-variables-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/library-variables-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma`
+Discovers variables available from subscribed team libraries and imports them into the current file by key.
+
+#### manage-variables-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/manage-variables-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_variable_defs`
+Performs create, update, rename, and delete operations on Figma variables, collections, and modes, including batch creation and updates.
+
+#### setup-design-tokens-figma
+
+[SOURCE CODE](https://github.com/southleft/skills-for-figma/tree/main/skills/setup-design-tokens-figma) · [MIT](https://github.com/southleft/skills-for-figma/blob/main/LICENSE)
+**MCP Tools:** `use_figma` `get_variable_defs`
+Bootstraps a complete token system — a collection, its modes, and all variables with per-mode values — in a single atomic operation.
 
 ---
 


### PR DESCRIPTION
Adds 18 open-source agent skills for the native Figma MCP server, from [`southleft/skills-for-figma`](https://github.com/southleft/skills-for-figma). Each skill runs via `use_figma` (Plugin API) and works on any Figma plan.

Entries are added to the existing category sections, alphabetically within each. **Additive only — no existing entries were changed (108 insertions, 0 deletions).**

### Skills added
- **Accessibility:** `audit-accessibility-figma`, `lint-design-figma`, `scan-code-accessibility-figma`
- **Components:** `analyze-component-set-figma`, `arrange-component-set-figma`, `component-properties-figma`, `deep-component-figma`, `generate-component-doc-figma`
- **Design Generation:** `build-slides-figma`
- **Design Process:** `annotations-figma`, `check-design-parity-figma`, `create-figjam-content`
- **Design Systems:** `design-system-inventory-figma`, `export-tokens-figma`, `import-tokens-figma`, `library-variables-figma`, `manage-variables-figma`, `setup-design-tokens-figma`

### Contribution checklist
- [x] Resource names do not start with "Figma" (suffixed `-figma`)
- [x] Objective descriptions — first character uppercase, ending in a period
- [x] Entries placed alphabetically within their section
- [x] `MIT` license at the repo root
- [x] Repo carries the `figma` + `figma-mcp` GitHub topics
- [x] Active project; installs via `npx skills add southleft/skills-for-figma` and as a Claude Code plugin (`/plugin marketplace add southleft/skills-for-figma`)
- [x] To the best of my knowledge, this does not infringe any third party's intellectual property
