### PR TITLE
fix: update bulk-capture source URL to .claude/skills path

### DIFF
--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -87,7 +87,7 @@ A skill that takes a selected Figma frame and rebuilds it as a proper Atomic Des
 A skill that generates Figma designs fully bound to your design system. Extracts components, variables, and text styles into a local knowledge base, then compiles declarative scene graphs into Figma Plugin API code executed via MCP. All output uses real component instances, bound variables, and token references — no hardcoded values. Includes a recipe system that learns from corrections to improve future generations.
 
 #### bulk-capture
-[SOURCE CODE](https://github.com/tallneil/tallneil-mono-public/tree/main/skills/bulk-capture) · [CC0](https://github.com/tallneil/tallneil-mono-public/blob/main/LICENSE)
+[SOURCE CODE](https://github.com/tallneil/tallneil-mono-public/tree/main/.claude/skills/bulk-capture) · [CC0](https://github.com/tallneil/tallneil-mono-public/blob/main/LICENSE)
 **MCP Tools:** `generate_figma_design` `new_page`
 
 A skill for bulk-capturing many live web app pages into Figma simultaneously using generate_figma_design and Chrome DevTools MCP. Opens all tabs in parallel and polls all capture IDs at once — no manual clicking required.


### PR DESCRIPTION
The `bulk-capture` skill has moved from `skills/bulk-capture/` to `.claude/skills/bulk-capture/` in the source repo to align with the Claude Code convention for skill discovery. Updates the listing URL accordingly.