### PR TITLE
Add [skill] video-interaction-mapper

### DIFF
--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -183,6 +183,12 @@ Writes a four-part design rationale from a Figma file covering context, insight,
 **MCP Tools:** `get_metadata` `get_design_context` `get_screenshot` `use_figma`
 Generates an information architecture page inside the Figma file with a sitemap and per-screen content hierarchy, export-ready as PDF.
 
+#### video-interaction-mapper
+
+[SOURCE CODE](https://github.com/ilin-figma/mcp-server-guide/tree/video-interaction-mapper/workflow-skills/video-interaction-mapper) · [MIT](https://github.com/ilin-figma/mcp-server-guide/blob/video-interaction-mapper/workflow-skills/video-interaction-mapper/LICENSE)
+**MCP Tools:** `create_new_file` `use_figma` `upload_assets` `get_screenshot`
+Maps UI screen recordings into annotated Figma storyboards with before/after screenshot states, target markers, and native annotations.
+
 ---
 
 **[⬆ Back to TOC](#table-of-contents)**


### PR DESCRIPTION
## Summary
- Add video-interaction-mapper to the Agent Skill Resources index under Design Process
- Include source, license, MCP tool list, and objective description following the contribution format

## Notes
- Source skill PR: https://github.com/figma/mcp-server-guide/pull/71
- The current source link points to the public fork branch so reviewers can inspect it immediately.