### PR TITLE
Add [skill] saas-ux-review

### DIFF
--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -178,6 +178,12 @@ Audits Figma designs for emotional quality across three dimensions: unexpected j
 **MCP Tools:** `get_design_context` `get_metadata` `get_screenshot`
 Writes a four-part design rationale from a Figma file covering context, insight, design response, and delight intention.
 
+#### saas-ux-review
+
+[SOURCE CODE](https://github.com/Israjkhan/saas-ux-review) · [MIT](https://github.com/Israjkhan/saas-ux-review/blob/main/LICENSE)
+**MCP Tools:** `get_design_context` `get_screenshot` `get_metadata`
+Reviews SaaS screens and user flows for usability, onboarding, activation, navigation, information architecture, workflow efficiency, conversion, retention, trust, accessibility, responsive behavior, and missing states, producing prioritized findings with evidence, severity, impact, and actionable recommendations.
+
 #### screens-to-ia
 
 [SOURCE CODE](https://github.com/mariespreitzer/screens-to-ia-figma) · [MIT](https://github.com/mariespreitzer/screens-to-ia-figma/blob/main/LICENSE)

--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -182,7 +182,7 @@ Writes a four-part design rationale from a Figma file covering context, insight,
 
 [SOURCE CODE](https://github.com/Israjkhan/saas-ux-review) · [MIT](https://github.com/Israjkhan/saas-ux-review/blob/main/LICENSE)
 **MCP Tools:** `get_design_context` `get_screenshot` `get_metadata`
-Reviews SaaS screens and user flows for usability, onboarding, activation, navigation, information architecture, workflow efficiency, conversion, retention, trust, accessibility, responsive behavior, and missing states, producing prioritized findings with evidence, severity, impact, and actionable recommendations.
+Reviews SaaS products, screens, and user flows for usability, onboarding, activation, navigation, information architecture, workflow efficiency, conversion, retention, trust, accessibility, responsive behavior, and missing states. Produces prioritized findings with evidence and actionable recommendations.
 
 #### screens-to-ia
 


### PR DESCRIPTION
Related to #66

## Summary

Adds a new `saas-ux-review` agent skill for reviewing SaaS products and user flows in Figma.

## What it does

The skill evaluates SaaS experiences across:

- Product clarity
- Information architecture
- Navigation
- Onboarding
- Activation
- Core workflows
- Dashboard UX
- Forms and data entry
- Conversion and monetization
- Retention
- Trust and transparency
- AI SaaS UX
- Accessibility
- Responsive UX
- Missing states

It produces prioritized UX findings with:

- Evidence
- Severity
- Impact
- Confidence
- Actionable recommendations

## Behavior

The skill is designed to review rather than redesign.

It does not modify the Figma canvas unless the user explicitly asks for design changes.

## Repository

https://github.com/Israjkhan/saas-ux-review

## License

MIT

## MCP Tools

- `get_design_context`
- `get_screenshot`
- `get_metadata`